### PR TITLE
4.8. Работа с размерами и ограничениями

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: appTitle,
       theme: themeData,
-      home: SightListScreen(sights: mocks),
+      home: SightDetails(description: mockDescription),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:places/mocks.dart';
 import 'package:places/ui/res/strings/strings.dart';
 import 'package:places/ui/res/styles.dart';
 import 'package:places/ui/screen/sight_details.dart';
+import 'package:places/ui/screen/sight_list_screen.dart';
 
 void main() {
   runApp(App());
@@ -18,7 +19,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: appTitle,
       theme: themeData,
-      home: SightDetails(description: mockDescription),
+      home: SightListScreen(sights: mocks),
     );
   }
 }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -13,16 +13,12 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AspectRatio(
-      aspectRatio: 3 / 2,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _CardImageContainer(sight: sight),
-          SizedBox(height: 10),
-          _DiscriptionContainer(sight: sight),
-        ],
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _CardImageContainer(sight: sight),
+        _DiscriptionContainer(sight: sight),
+      ],
     );
   }
 }
@@ -50,19 +46,13 @@ class _DiscriptionContainer extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.5,
-            ),
-            child: Container(
-              height: 40,
-              color: Colors.lightBlue,
-              child: Text(
-                '${sight.name}',
-                style: textMeduim16Secondary,
-                maxLines: 2,
-                overflow: TextOverflow.fade,
-              ),
+          Container(
+            height: 40,
+            child: Text(
+              '${sight.name}',
+              style: textMeduim16Secondary,
+              maxLines: 2,
+              overflow: TextOverflow.fade,
             ),
           ),
           SizedBox(height: 2),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -13,16 +13,30 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _buildImageContainer(),
-        _buildDescriptionContainer(),
-      ],
+    return AspectRatio(
+      aspectRatio: 3 / 2,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _CardImageContainer(sight: sight),
+          SizedBox(height: 10),
+          _DiscriptionContainer(sight: sight),
+        ],
+      ),
     );
   }
+}
 
-  Widget _buildDescriptionContainer() {
+class _DiscriptionContainer extends StatelessWidget {
+  const _DiscriptionContainer({
+    Key key,
+    @required this.sight,
+  }) : super(key: key);
+
+  final Sight sight;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
         color: cardBackground,
@@ -36,18 +50,22 @@ class SightCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SizedBox(
-            height: 40,
-            child: Text(
-              '${sight.name}',
-              style: textMeduim16Secondary,
-              maxLines: 2,
-              overflow: TextOverflow.fade,
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.5,
+            ),
+            child: Container(
+              height: 40,
+              color: Colors.lightBlue,
+              child: Text(
+                '${sight.name}',
+                style: textMeduim16Secondary,
+                maxLines: 2,
+                overflow: TextOverflow.fade,
+              ),
             ),
           ),
-          SizedBox(
-            height: 2,
-          ),
+          SizedBox(height: 2),
           Text(
             '${sight.details}',
             style: textRegular14Secondary1,
@@ -58,13 +76,21 @@ class SightCard extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildImageContainer() {
+class _CardImageContainer extends StatelessWidget {
+  const _CardImageContainer({
+    Key key,
+    @required this.sight,
+  }) : super(key: key);
+  final Sight sight;
+
+  @override
+  Widget build(BuildContext context) {
     return Stack(
       children: [
         Container(
-          //Картинка превью достопримечательности
-          height: PRVIEW_IMAGE_HEIGT,
+          height: 96,
           decoration: BoxDecoration(
             color: imageMockColor,
             borderRadius: const BorderRadius.only(

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -12,69 +12,96 @@ class SightDetails extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        elevation: 0,
-        toolbarHeight: 360,
-        flexibleSpace: Stack(
-          children: [
-            Container(
-              color: imageMockColor,
-            ),
-            Positioned(
-              top: 36,
-              left: 16,
-              child: _AppBarBackButtonInverse(onBackPressed: () => {}),
-            )
-          ],
-        ),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const SizedBox(height: 24),
-                Text(
-                  description.name,
-                  style: textBold24Secondary,
-                  maxLines: 2,
-                ),
-                const SizedBox(height: 2),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.baseline,
-                  textBaseline: TextBaseline.alphabetic,
-                  children: [
-                    Text(description.type, style: textBold14),
-                    const SizedBox(width: 16),
-                    Text(description.workHours, style: textRegular14Secondary1),
-                  ],
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  description.description,
-                  style: textRegular14Secondary.copyWith(height: 1.3),
-                ),
-                const SizedBox(height: 24),
-                _ActionButton(),
-                const SizedBox(height: 24),
-                _Divider(),
-                const SizedBox(height: 8),
-                Row(
-                  mainAxisSize: MainAxisSize.max,
-                  children: [
-                    Expanded(child: _SecondaryActionButton()),
-                    Expanded(child: _SecondaryActionButton()),
-                  ],
-                ),
-              ],
-            ),
+      appBar: _DetailsAppBar(),
+      body: _DetailsBody(description: description),
+    );
+  }
+}
+
+class _DetailsBody extends StatelessWidget {
+  const _DetailsBody({
+    Key key,
+    @required this.description,
+  }) : super(key: key);
+
+  final SightDescription description;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 24),
+              Text(
+                description.name,
+                style: textBold24Secondary,
+                maxLines: 2,
+              ),
+              const SizedBox(height: 2),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(description.type, style: textBold14),
+                  const SizedBox(width: 16),
+                  Text(description.workHours, style: textRegular14Secondary1),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Text(
+                description.description,
+                style: textRegular14Secondary.copyWith(height: 1.3),
+              ),
+              const SizedBox(height: 24),
+              _ActionButton(),
+              const SizedBox(height: 24),
+              _Divider(),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  Expanded(child: _SecondaryActionButton()),
+                  Expanded(child: _SecondaryActionButton()),
+                ],
+              ),
+            ],
           ),
         ),
       ),
     );
   }
+}
+
+class _DetailsAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _DetailsAppBar({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      elevation: 0,
+      flexibleSpace: Stack(
+        children: [
+          Container(
+            color: imageMockColor,
+          ),
+          Positioned(
+            top: 36,
+            left: 16,
+            child: _AppBarBackButtonInverse(onBackPressed: () => {}),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(360);
 }
 
 class _SecondaryActionButton extends StatelessWidget {

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -13,7 +13,7 @@ class SightDetails extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: _DetailsAppBar(),
-      body: _DetailsBody(description: description),
+      body: SafeArea(child: _DetailsBody(description: description)),
     );
   }
 }


### PR DESCRIPTION
В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся? После выполнения,  отрегулируйте размер текста согласно дизайну.

Ответ: 
В данном случае изменилась максимальная ширина, которую может занимать текст. Теперь ширина текста не может больше, чем ширина карточки минус паддинги(наложены на родительский контейнер с описанием). Визуально - длинные тексты теперь занимают в 2 раза меньше ширины. 
Эти визуальные изменения проиcходят потому, что для текста добавлен родитель - ConstrainedBox, который переопределил ограничения выставленные родителем верхнего уровня

constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.5)

Согласно правилу - ограничения определяет родитель. Данный ConstrainedBox установил для потомков новые ограничения по максимальной ширине, которую том может занимать (в коде потомок Text).

Ограничить размер пропорционально размеру родителя также можно с помощью виджета
FractionallySizedBox()


Добавьте отступ между между фотографиями и описанием с помощью SizedBox


AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2
Ответ:
Просто добавил AspectRatio родителем для контейнера карты.


Переверстать AppBar через наследника PreferredSizeWidget.
Ответ: Переверстал экран SightDetails